### PR TITLE
Bugfix - remove isTesting variable

### DIFF
--- a/src/Amplitude.js
+++ b/src/Amplitude.js
@@ -283,7 +283,6 @@
 
             forwarderSettings = settings;
             reportingService = service;
-            isTesting = testMode;
 
             try {
                 if (!window.amplitude) {


### PR DESCRIPTION
`isTesting` was never declared, which broke builds if the self hosted and were using strict mode.

It was not actually being used, so rather than declare it, I just removed it