### PR TITLE
feat - Align with server by adding includeEmailAsUserProperty and no longer setting user identities as user properties

### DIFF
--- a/src/Amplitude.js
+++ b/src/Amplitude.js
@@ -157,6 +157,7 @@ var constructor = function () {
                 switch (forwarderSettings.userIdentification) {
                     case constants.MPID:
                         return getInstance().setUserId(user.getMPID());
+                    // server returns `customerId` whereas key on userIdentities object is `customerid`
                     case constants.customerId:
                         if (userIdentities.customerid) {
                             return getInstance().setUserId(

--- a/src/Amplitude.js
+++ b/src/Amplitude.js
@@ -30,6 +30,12 @@ var name = 'Amplitude',
 
 var constants = {
     MPID: 'mpId',
+    customerId: 'customerId',
+    email: 'email',
+    other: 'other',
+    other2: 'other2',
+    other3: 'other3',
+    other4: 'other4',
 };
 
 /* eslint-disable */
@@ -119,25 +125,107 @@ var constructor = function () {
     }
 
     function setUserIdentity(id, type) {
-        if (isInitialized) {
-            if (type === window.mParticle.IdentityType.CustomerId) {
-                getInstance().setUserId(id);
+        if (window.mParticle.getVersion()[0] !== '1') {
+            if (isInitialized) {
+                if (type === window.mParticle.IdentityType.CustomerId) {
+                    getInstance().setUserId(id);
+                } else {
+                    setUserAttribute(getIdentityTypeName(type), id);
+                }
             } else {
-                setUserAttribute(getIdentityTypeName(type), id);
+                return (
+                    'Cannot call setUserIdentity on forwarder ' +
+                    name +
+                    ', not initialized'
+                );
             }
-        } else {
-            return (
-                'Cannot call setUserIdentity on forwarder ' +
-                name +
-                ', not initialized'
-            );
         }
     }
 
     function onUserIdentified(user) {
+        var userIdMissing;
         if (isInitialized) {
-            if (forwarderSettings.userIdentification === constants.MPID) {
-                getInstance().setUserId(user.getMPID());
+            var userIdentities = user.getUserIdentities().userIdentities;
+            try {
+                switch (forwarderSettings.userIdentification) {
+                    case constants.MPID:
+                        return getInstance().setUserId(user.getMPID());
+                    case constants.customerId:
+                        if (userIdentities.customerid) {
+                            return getInstance().setUserId(
+                                userIdentities.customerid
+                            );
+                        } else {
+                            userIdMissing = true;
+                        }
+                        break;
+                    case constants.email:
+                        if (userIdentities.email) {
+                            // Additional check for email to match server
+                            if (
+                                forwarderSettings.includeEmailAsUserProperty ===
+                                'True'
+                            ) {
+                                setUserAttribute('email', userIdentities.email);
+                            }
+                            return getInstance().setUserId(
+                                userIdentities.email
+                            );
+                        } else {
+                            userIdMissing = true;
+                        }
+                        break;
+                    case constants.other:
+                        if (userIdentities.other) {
+                            return getInstance().setUserId(
+                                userIdentities.other
+                            );
+                        } else {
+                            userIdMissing = true;
+                        }
+                        break;
+                    case constants.other2:
+                        if (userIdentities.other2) {
+                            return getInstance().setUserId(
+                                userIdentities.other2
+                            );
+                        } else {
+                            userIdMissing = true;
+                        }
+                        break;
+                    case constants.other3:
+                        if (userIdentities.other3) {
+                            return getInstance().setUserId(
+                                userIdentities.other3
+                            );
+                        } else {
+                            userIdMissing = true;
+                        }
+                        break;
+                    case constants.other4:
+                        if (userIdentities.other4) {
+                            return getInstance().setUserId(
+                                userIdentities.other4
+                            );
+                        } else {
+                            userIdMissing = true;
+                        }
+                        break;
+
+                    default:
+                        return;
+                }
+                if (userIdMissing) {
+                    console.warn(
+                        'A user identification type of ' +
+                            forwarderSettings.userIdentification +
+                            ' was selected in mParticle dashboard, but was not passed to the identity call. Please check your implementation.'
+                    );
+                }
+            } catch (e) {
+                console.error(
+                    'Error calling onUserIdentified on forwarder ' + name
+                );
             }
         } else {
             return (

--- a/src/Amplitude.js
+++ b/src/Amplitude.js
@@ -147,6 +147,12 @@ var constructor = function () {
         var userIdMissing;
         if (isInitialized) {
             var userIdentities = user.getUserIdentities().userIdentities;
+
+            // Additional check for email to match server
+            if (forwarderSettings.includeEmailAsUserProperty === 'True') {
+                setUserAttribute('email', userIdentities.email);
+            }
+
             try {
                 switch (forwarderSettings.userIdentification) {
                     case constants.MPID:
@@ -162,13 +168,6 @@ var constructor = function () {
                         break;
                     case constants.email:
                         if (userIdentities.email) {
-                            // Additional check for email to match server
-                            if (
-                                forwarderSettings.includeEmailAsUserProperty ===
-                                'True'
-                            ) {
-                                setUserAttribute('email', userIdentities.email);
-                            }
                             return getInstance().setUserId(
                                 userIdentities.email
                             );

--- a/src/Amplitude.js
+++ b/src/Amplitude.js
@@ -126,19 +126,20 @@ var constructor = function () {
 
     function setUserIdentity(id, type) {
         if (window.mParticle.getVersion()[0] !== '1') {
-            if (isInitialized) {
-                if (type === window.mParticle.IdentityType.CustomerId) {
-                    getInstance().setUserId(id);
-                } else {
-                    setUserAttribute(getIdentityTypeName(type), id);
-                }
+            return;
+        }
+        if (isInitialized) {
+            if (type === window.mParticle.IdentityType.CustomerId) {
+                getInstance().setUserId(id);
             } else {
-                return (
-                    'Cannot call setUserIdentity on forwarder ' +
-                    name +
-                    ', not initialized'
-                );
+                setUserAttribute(getIdentityTypeName(type), id);
             }
+        } else {
+            return (
+                'Cannot call setUserIdentity on forwarder ' +
+                name +
+                ', not initialized'
+            );
         }
     }
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -233,7 +233,6 @@ describe('Amplitude forwarder', function () {
             'customerId1',
             IdentityType.CustomerId
         );
-
         amplitude.instances.newInstance.should.have.property(
             'userId',
             'customerId1'
@@ -253,6 +252,20 @@ describe('Amplitude forwarder', function () {
         );
 
         amplitude.instances.newInstance.should.have.property('userId', '123');
+
+        done();
+    });
+
+    it('should set user identities as user attributes for non customerid user identities', function (done) {
+        mParticle.getVersion = function () {
+            return '1.16.3';
+        };
+        mParticle.forwarder.setUserIdentity('other1', IdentityType.Other);
+
+        amplitude.instances.newInstance.props.should.have.property(
+            'Other',
+            'other1'
+        );
 
         done();
     });
@@ -279,6 +292,26 @@ describe('Amplitude forwarder', function () {
                     };
                 },
             };
+
+            it('should not set userId as a user attribute when on v2', function (done) {
+                mParticle.forwarder.init(
+                    {
+                        userIdentification: 'other2',
+                        instanceName: 'newInstance',
+                    },
+                    reportService.cb,
+                    true
+                );
+
+                mParticle.forwarder.onUserIdentified(mParticleUser);
+
+                amplitude.instances.newInstance.should.have.property(
+                    'props',
+                    null
+                );
+
+                done();
+            });
 
             it('should set userId as MPID on onUserIdentified if forwarder settings has MPID as userIdField', function (done) {
                 mParticle.forwarder.init(

--- a/test/tests.js
+++ b/test/tests.js
@@ -254,26 +254,309 @@ describe('Amplitude forwarder', function () {
         done();
     });
 
-    it('should set userId as MPID on onUserIdentified if forwarder settings has MPID as userIdField', function (done) {
-        var mParticleUser = {
-            getMPID: function () {
-                return 'abc';
-            },
-        };
-        mParticle.forwarder.init(
-            {
-                userIdentification: 'mpId',
-                instanceName: 'newInstance',
-            },
-            reportService.cb,
-            true
-        );
+    describe('Identity', function () {
+        describe('Identity exists', function () {
+            var mParticleUser = {
+                getMPID: function () {
+                    return 'abc';
+                },
+                getUserIdentities: function () {
+                    return {
+                        userIdentities: {
+                            customerid: 'customerid',
+                            email: 'email',
+                            other: 'other',
+                            other2: 'other2',
+                            other3: 'other3',
+                            other4: 'other4',
+                        },
+                    };
+                },
+            };
 
-        mParticle.forwarder.onUserIdentified(mParticleUser);
+            it('should set userId as MPID on onUserIdentified if forwarder settings has MPID as userIdField', function (done) {
+                mParticle.forwarder.init(
+                    {
+                        userIdentification: 'mpId',
+                        instanceName: 'newInstance',
+                    },
+                    reportService.cb,
+                    true
+                );
 
-        amplitude.instances.newInstance.should.have.property('userId', 'abc');
+                mParticle.forwarder.onUserIdentified(mParticleUser);
 
-        done();
+                amplitude.instances.newInstance.should.have.property(
+                    'userId',
+                    'abc'
+                );
+
+                done();
+            });
+
+            it('should set userId as customerid on onUserIdentified if forwarder settings has customerId as userIdField', function (done) {
+                mParticle.forwarder.init(
+                    {
+                        userIdentification: 'customerId',
+                        instanceName: 'newInstance',
+                    },
+                    reportService.cb,
+                    true
+                );
+
+                mParticle.forwarder.onUserIdentified(mParticleUser);
+
+                amplitude.instances.newInstance.should.have.property(
+                    'userId',
+                    'customerid'
+                );
+
+                done();
+            });
+
+            it('should set userId as email on onUserIdentified if forwarder settings has email as userIdField', function (done) {
+                mParticle.forwarder.init(
+                    {
+                        userIdentification: 'email',
+                        instanceName: 'newInstance',
+                    },
+                    reportService.cb,
+                    true
+                );
+
+                mParticle.forwarder.onUserIdentified(mParticleUser);
+
+                amplitude.instances.newInstance.should.have.property(
+                    'userId',
+                    'email'
+                );
+
+                done();
+            });
+
+            it('should set userId as other on onUserIdentified if forwarder settings has other as userIdField', function (done) {
+                mParticle.forwarder.init(
+                    {
+                        userIdentification: 'other',
+                        instanceName: 'newInstance',
+                    },
+                    reportService.cb,
+                    true
+                );
+
+                mParticle.forwarder.onUserIdentified(mParticleUser);
+
+                amplitude.instances.newInstance.should.have.property(
+                    'userId',
+                    'other'
+                );
+
+                done();
+            });
+
+            it('should set userId as other2 on onUserIdentified if forwarder settings has other2 as userIdField', function (done) {
+                mParticle.forwarder.init(
+                    {
+                        userIdentification: 'other2',
+                        instanceName: 'newInstance',
+                    },
+                    reportService.cb,
+                    true
+                );
+
+                mParticle.forwarder.onUserIdentified(mParticleUser);
+
+                amplitude.instances.newInstance.should.have.property(
+                    'userId',
+                    'other2'
+                );
+
+                done();
+            });
+
+            it('should set userId as other3 on onUserIdentified if forwarder settings has other3 as userIdField', function (done) {
+                mParticle.forwarder.init(
+                    {
+                        userIdentification: 'other3',
+                        instanceName: 'newInstance',
+                    },
+                    reportService.cb,
+                    true
+                );
+
+                mParticle.forwarder.onUserIdentified(mParticleUser);
+
+                amplitude.instances.newInstance.should.have.property(
+                    'userId',
+                    'other3'
+                );
+
+                done();
+            });
+
+            it('should set userId as other4 on onUserIdentified if forwarder settings has other4 as userIdField', function (done) {
+                mParticle.forwarder.init(
+                    {
+                        userIdentification: 'other4',
+                        instanceName: 'newInstance',
+                    },
+                    reportService.cb,
+                    true
+                );
+
+                mParticle.forwarder.onUserIdentified(mParticleUser);
+
+                amplitude.instances.newInstance.should.have.property(
+                    'userId',
+                    'other4'
+                );
+
+                done();
+            });
+        });
+
+        describe('Identity does not exist', function () {
+            var mParticleUser = {
+                getUserIdentities: function () {
+                    return {
+                        userIdentities: {},
+                    };
+                },
+            };
+
+            it('should set userId as MPID on onUserIdentified if forwarder settings has MPID as userIdField', function (done) {
+                mParticle.forwarder.init(
+                    {
+                        userIdentification: 'mpId',
+                        instanceName: 'newInstance',
+                    },
+                    reportService.cb,
+                    true
+                );
+
+                mParticle.forwarder.onUserIdentified(mParticleUser);
+
+                amplitude.instances.newInstance.should.not.have.property(
+                    'userId'
+                );
+
+                done();
+            });
+
+            it('should set userId as customerid on onUserIdentified if forwarder settings has customerId as userIdField', function (done) {
+                mParticle.forwarder.init(
+                    {
+                        userIdentification: 'customerId',
+                        instanceName: 'newInstance',
+                    },
+                    reportService.cb,
+                    true
+                );
+
+                mParticle.forwarder.onUserIdentified(mParticleUser);
+
+                amplitude.instances.newInstance.should.not.have.property(
+                    'userId'
+                );
+
+                done();
+            });
+
+            it('should set userId as email on onUserIdentified if forwarder settings has email as userIdField', function (done) {
+                mParticle.forwarder.init(
+                    {
+                        userIdentification: 'email',
+                        instanceName: 'newInstance',
+                    },
+                    reportService.cb,
+                    true
+                );
+
+                mParticle.forwarder.onUserIdentified(mParticleUser);
+
+                amplitude.instances.newInstance.should.not.have.property(
+                    'userId'
+                );
+
+                done();
+            });
+
+            it('should set userId as other on onUserIdentified if forwarder settings has other as userIdField', function (done) {
+                mParticle.forwarder.init(
+                    {
+                        userIdentification: 'other',
+                        instanceName: 'newInstance',
+                    },
+                    reportService.cb,
+                    true
+                );
+
+                mParticle.forwarder.onUserIdentified(mParticleUser);
+
+                amplitude.instances.newInstance.should.not.have.property(
+                    'userId'
+                );
+
+                done();
+            });
+
+            it('should set userId as other2 on onUserIdentified if forwarder settings has other2 as userIdField', function (done) {
+                mParticle.forwarder.init(
+                    {
+                        userIdentification: 'other2',
+                        instanceName: 'newInstance',
+                    },
+                    reportService.cb,
+                    true
+                );
+
+                mParticle.forwarder.onUserIdentified(mParticleUser);
+
+                amplitude.instances.newInstance.should.not.have.property(
+                    'userId'
+                );
+
+                done();
+            });
+
+            it('should set userId as other3 on onUserIdentified if forwarder settings has other3 as userIdField', function (done) {
+                mParticle.forwarder.init(
+                    {
+                        userIdentification: 'other3',
+                        instanceName: 'newInstance',
+                    },
+                    reportService.cb,
+                    true
+                );
+
+                mParticle.forwarder.onUserIdentified(mParticleUser);
+
+                amplitude.instances.newInstance.should.not.have.property(
+                    'userId'
+                );
+
+                done();
+            });
+
+            it('should set userId as other4 on onUserIdentified if forwarder settings has other4 as userIdField', function (done) {
+                mParticle.forwarder.init(
+                    {
+                        userIdentification: 'other4',
+                        instanceName: 'newInstance',
+                    },
+                    reportService.cb,
+                    true
+                );
+
+                mParticle.forwarder.onUserIdentified(mParticleUser);
+
+                amplitude.instances.newInstance.should.not.have.property(
+                    'userId'
+                );
+
+                done();
+            });
+        });
     });
 
     it('should set user attribute', function (done) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -256,7 +256,7 @@ describe('Amplitude forwarder', function () {
         done();
     });
 
-    it('should set user identities as user attributes for non customerid user identities', function (done) {
+    it('should set user identities as user attributes for non customerid user identities in v1', function (done) {
         mParticle.getVersion = function () {
             return '1.16.3';
         };
@@ -293,7 +293,7 @@ describe('Amplitude forwarder', function () {
                 },
             };
 
-            it('should not set userId as a user attribute when on v2', function (done) {
+            it('should not set any userId as a user attribute when on v2', function (done) {
                 mParticle.forwarder.init(
                     {
                         userIdentification: 'other2',
@@ -308,6 +308,27 @@ describe('Amplitude forwarder', function () {
                 amplitude.instances.newInstance.should.have.property(
                     'props',
                     null
+                );
+
+                done();
+            });
+
+            it('should set email as a user attribute when includeEmailAsUserProperty is True', function (done) {
+                mParticle.forwarder.init(
+                    {
+                        userIdentification: 'other2',
+                        instanceName: 'newInstance',
+                        includeEmailAsUserProperty: 'True',
+                    },
+                    reportService.cb,
+                    true
+                );
+
+                mParticle.forwarder.onUserIdentified(mParticleUser);
+
+                amplitude.instances.newInstance.props.should.have.property(
+                    'email',
+                    'email'
                 );
 
                 done();

--- a/test/tests.js
+++ b/test/tests.js
@@ -226,6 +226,9 @@ describe('Amplitude forwarder', function () {
     });
 
     it('should set customer id user identity', function (done) {
+        mParticle.getVersion = function () {
+            return '1.16.3';
+        };
         mParticle.forwarder.setUserIdentity(
             'customerId1',
             IdentityType.CustomerId
@@ -255,6 +258,9 @@ describe('Amplitude forwarder', function () {
     });
 
     describe('Identity', function () {
+        mParticle.getVersion = function () {
+            return '2.x.y';
+        };
         describe('Identity exists', function () {
             var mParticleUser = {
                 getMPID: function () {
@@ -424,25 +430,6 @@ describe('Amplitude forwarder', function () {
                 },
             };
 
-            it('should set userId as MPID on onUserIdentified if forwarder settings has MPID as userIdField', function (done) {
-                mParticle.forwarder.init(
-                    {
-                        userIdentification: 'mpId',
-                        instanceName: 'newInstance',
-                    },
-                    reportService.cb,
-                    true
-                );
-
-                mParticle.forwarder.onUserIdentified(mParticleUser);
-
-                amplitude.instances.newInstance.should.not.have.property(
-                    'userId'
-                );
-
-                done();
-            });
-
             it('should set userId as customerid on onUserIdentified if forwarder settings has customerId as userIdField', function (done) {
                 mParticle.forwarder.init(
                     {
@@ -455,8 +442,9 @@ describe('Amplitude forwarder', function () {
 
                 mParticle.forwarder.onUserIdentified(mParticleUser);
 
-                amplitude.instances.newInstance.should.not.have.property(
-                    'userId'
+                amplitude.instances.newInstance.should.have.property(
+                    'userId',
+                    null
                 );
 
                 done();
@@ -474,8 +462,9 @@ describe('Amplitude forwarder', function () {
 
                 mParticle.forwarder.onUserIdentified(mParticleUser);
 
-                amplitude.instances.newInstance.should.not.have.property(
-                    'userId'
+                amplitude.instances.newInstance.should.have.property(
+                    'userId',
+                    null
                 );
 
                 done();
@@ -493,8 +482,9 @@ describe('Amplitude forwarder', function () {
 
                 mParticle.forwarder.onUserIdentified(mParticleUser);
 
-                amplitude.instances.newInstance.should.not.have.property(
-                    'userId'
+                amplitude.instances.newInstance.should.have.property(
+                    'userId',
+                    null
                 );
 
                 done();
@@ -512,8 +502,9 @@ describe('Amplitude forwarder', function () {
 
                 mParticle.forwarder.onUserIdentified(mParticleUser);
 
-                amplitude.instances.newInstance.should.not.have.property(
-                    'userId'
+                amplitude.instances.newInstance.should.have.property(
+                    'userId',
+                    null
                 );
 
                 done();
@@ -531,8 +522,9 @@ describe('Amplitude forwarder', function () {
 
                 mParticle.forwarder.onUserIdentified(mParticleUser);
 
-                amplitude.instances.newInstance.should.not.have.property(
-                    'userId'
+                amplitude.instances.newInstance.should.have.property(
+                    'userId',
+                    null
                 );
 
                 done();
@@ -550,8 +542,9 @@ describe('Amplitude forwarder', function () {
 
                 mParticle.forwarder.onUserIdentified(mParticleUser);
 
-                amplitude.instances.newInstance.should.not.have.property(
-                    'userId'
+                amplitude.instances.newInstance.should.have.property(
+                    'userId',
+                    null
                 );
 
                 done();


### PR DESCRIPTION
A few items addressed in this PR:
* previously, we only set user ids based off of MPID. However, our UI shows `customerid`, `email`, `other/2,3,4` as options as well.
* If `setUserIdentity` and `onUserIdentity` both exist on the kit, we should only use `onUserIdentity`, as `setUserIdentity` should only be used on version 1 of the core SDK. See [mixpanel](https://github.com/mparticle-integrations/mparticle-javascript-integration-mixpanel/blob/master/src/MixpanelEventForwarder.js#L101) as an example

This puts the web kit in line with our server kit.  The server kit does not set user identities as user properties. This PR removes this functionality as well.