### PR TITLE
fix: Map impression and promotion events

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,9 @@
     "env": {
         "browser": true
     },
+    "globals": {
+        "mParticle": true
+    },
     "extends": ["plugin:prettier/recommended", "eslint:recommended"],
     "rules": {
         "prettier/prettier": "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,17 +5,17 @@
   "requires": true,
   "dependencies": {
     "@babel/runtime": {
-      "version": "7.9.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-      "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
+      "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@mparticle/web-sdk": {
-      "version": "2.11.9",
-      "resolved": "https://registry.npmjs.org/@mparticle/web-sdk/-/web-sdk-2.11.9.tgz",
-      "integrity": "sha512-no9E7YJapOoCypSlG0g3q9lo+Fxrv7yyai5y4xgSz+NIazLCXO5mrfpeW4V7q9nU3QUy0AVjRT+xfgd67Hxn3g==",
+      "version": "2.12.8",
+      "resolved": "https://registry.npmjs.org/@mparticle/web-sdk/-/web-sdk-2.12.8.tgz",
+      "integrity": "sha512-+K5L90lumJhAm86VltOfkBoxdFNRLDd9n0c78Y4Hq9HxPK8j3E2gcISMoad8xo9N4CpPDgHrbmBQYeOMTQAZAg==",
       "requires": {
         "@babel/runtime": "^7.6.0",
         "slugify": "^1.3.6"
@@ -3167,9 +3167,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "regex-not": {
       "version": "1.0.2",
@@ -3509,9 +3509,9 @@
       "dev": true
     },
     "slugify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.0.tgz",
-      "integrity": "sha512-FtLNsMGBSRB/0JOE2A0fxlqjI6fJsgHGS13iTuVT28kViI4JjUiNqp/vyis0ZXYcMnpR3fzGNkv+6vRlI2GwdQ=="
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.5.3.tgz",
+      "integrity": "sha512-/HkjRdwPY3yHJReXu38NiusZw2+LLE2SrhkWJtmlPDB1fqFSvioYj62NkPcrKiNCgRLeGcGK7QBvr1iQwybeXw=="
     },
     "snapdragon": {
       "version": "0.8.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "watchify": "^3.11.1"
   },
   "dependencies": {
-    "@mparticle/web-sdk": "^2.11.1",
+    "@mparticle/web-sdk": "^2.12.8",
     "isobject": "^4.0.0"
   },
   "license": "Apache-2.0"

--- a/src/Amplitude.js
+++ b/src/Amplitude.js
@@ -334,30 +334,33 @@ var constructor = function () {
         );
     }
 
+    function createEcommerceAttributes(attributes) {
+        var updatedAttributes = {};
+        for (var key in attributes) {
+            if (key !== 'Total Amount' && key !== 'Total Product Amount') {
+                updatedAttributes[key] = attributes[key];
+            }
+        }
+
+        return convertJsonAttrs(updatedAttributes);
+    }
+
     function logCommerce(event) {
+        var expandedEvents = mParticle.eCommerce.expandCommerceEvent(event);
         if (event.ProductAction) {
-            var expandedEvents = mParticle.eCommerce.expandCommerceEvent(event),
-                isRefund =
-                    event.ProductAction.ProductActionType ===
-                    mParticle.ProductActionType.Refund,
-                isPurchase =
-                    event.ProductAction.ProductActionType ===
-                    mParticle.ProductActionType.Purchase,
-                logRevenue = isRefund || isPurchase;
+            var isRefund, isPurchase, logRevenue;
+            isRefund =
+                event.ProductAction.ProductActionType ===
+                mParticle.ProductActionType.Refund;
+            isPurchase =
+                event.ProductAction.ProductActionType ===
+                mParticle.ProductActionType.Purchase;
+            logRevenue = isRefund || isPurchase;
             expandedEvents.forEach(function (expandedEvt) {
                 // Exclude Totals from the attributes as we log it in the revenue call
-                var updatedAttributes = {};
-                for (var key in expandedEvt.EventAttributes) {
-                    if (
-                        key !== 'Total Amount' &&
-                        key !== 'Total Product Amount'
-                    ) {
-                        updatedAttributes[key] =
-                            expandedEvt.EventAttributes[key];
-                    }
-                }
-
-                updatedAttributes = convertJsonAttrs(updatedAttributes);
+                var updatedAttributes = createEcommerceAttributes(
+                    expandedEvt.EventAttributes
+                );
 
                 // Purchase and Refund events generate an additional 'Total' event
                 if (logRevenue && expandedEvt.EventName.indexOf('Total') > -1) {
@@ -385,21 +388,11 @@ var constructor = function () {
             event.EventCategory === mParticle.CommerceEventType.PromotionView ||
             event.EventCategory === mParticle.CommerceEventType.PromotionClick
         ) {
-            expandedEvents = mParticle.eCommerce.expandCommerceEvent(event);
             expandedEvents.forEach(function (expandedEvt) {
                 // Exclude Totals from the attributes as we log it in the revenue call
-                var updatedAttributes = {};
-                for (var key in expandedEvt.EventAttributes) {
-                    if (
-                        key !== 'Total Amount' &&
-                        key !== 'Total Product Amount'
-                    ) {
-                        updatedAttributes[key] =
-                            expandedEvt.EventAttributes[key];
-                    }
-                }
-
-                updatedAttributes = convertJsonAttrs(updatedAttributes);
+                var updatedAttributes = createEcommerceAttributes(
+                    expandedEvt.EventAttributes
+                );
 
                 getInstance().logEvent(
                     expandedEvt.EventName,

--- a/src/Amplitude.js
+++ b/src/Amplitude.js
@@ -335,15 +335,15 @@ var constructor = function () {
     }
 
     function logCommerce(event) {
-        var expandedEvents;
         if (event.ProductAction) {
-            var isRefund =
-                event.ProductAction.ProductActionType ===
-                mParticle.ProductActionType.Refund;
-            var logRevenue =
-                event.ProductAction.ProductActionType ===
-                    mParticle.ProductActionType.Purchase || isRefund;
-            expandedEvents = mParticle.eCommerce.expandCommerceEvent(event);
+            var expandedEvents = mParticle.eCommerce.expandCommerceEvent(event),
+                isRefund =
+                    event.ProductAction.ProductActionType ===
+                    mParticle.ProductActionType.Refund,
+                isPurchase =
+                    event.ProductAction.ProductActionType ===
+                    mParticle.ProductActionType.Purchase,
+                logRevenue = isRefund || isPurchase;
             expandedEvents.forEach(function (expandedEvt) {
                 // Exclude Totals from the attributes as we log it in the revenue call
                 var updatedAttributes = {};
@@ -378,9 +378,12 @@ var constructor = function () {
 
             return true;
         }
+
         if (
             event.EventCategory ===
-            mParticle.CommerceEventType.ProductImpression
+                mParticle.CommerceEventType.ProductImpression ||
+            event.EventCategory === mParticle.CommerceEventType.PromotionView ||
+            event.EventCategory === mParticle.CommerceEventType.PromotionClick
         ) {
             expandedEvents = mParticle.eCommerce.expandCommerceEvent(event);
             expandedEvents.forEach(function (expandedEvt) {

--- a/src/Amplitude.js
+++ b/src/Amplitude.js
@@ -335,6 +335,7 @@ var constructor = function () {
     }
 
     function logCommerce(event) {
+        var expandedEvents;
         if (event.ProductAction) {
             var isRefund =
                 event.ProductAction.ProductActionType ===
@@ -342,7 +343,7 @@ var constructor = function () {
             var logRevenue =
                 event.ProductAction.ProductActionType ===
                     mParticle.ProductActionType.Purchase || isRefund;
-            var expandedEvents = mParticle.eCommerce.expandCommerceEvent(event);
+            expandedEvents = mParticle.eCommerce.expandCommerceEvent(event);
             expandedEvents.forEach(function (expandedEvt) {
                 // Exclude Totals from the attributes as we log it in the revenue call
                 var updatedAttributes = {};
@@ -375,6 +376,33 @@ var constructor = function () {
                 }
             });
 
+            return true;
+        }
+        if (
+            event.EventCategory ===
+            mParticle.CommerceEventType.ProductImpression
+        ) {
+            expandedEvents = mParticle.eCommerce.expandCommerceEvent(event);
+            expandedEvents.forEach(function (expandedEvt) {
+                // Exclude Totals from the attributes as we log it in the revenue call
+                var updatedAttributes = {};
+                for (var key in expandedEvt.EventAttributes) {
+                    if (
+                        key !== 'Total Amount' &&
+                        key !== 'Total Product Amount'
+                    ) {
+                        updatedAttributes[key] =
+                            expandedEvt.EventAttributes[key];
+                    }
+                }
+
+                updatedAttributes = convertJsonAttrs(updatedAttributes);
+
+                getInstance().logEvent(
+                    expandedEvt.EventName,
+                    updatedAttributes
+                );
+            });
             return true;
         }
 

--- a/test/boilerplate/test-index.js
+++ b/test/boilerplate/test-index.js
@@ -55,7 +55,7 @@ var amplitudeClient = function (instanceName) {
 
   this.init = function (key, arg1, settings) {
     self.settings = settings;
-    self.eventName = null;
+    self.events = [];;
     self.attrs = null;
     self.amount = null;
     self.quantity = null;
@@ -76,8 +76,10 @@ var amplitudeClient = function (instanceName) {
   };
 
   this.logEvent = function (name, attrs) {
-    self.eventName = name;
-    self.attrs = attrs;
+    self.events.push({
+        eventName: name,
+        attrs: attrs,
+    });
   };
 
   this.setOptOut = function (isOptingOut) {

--- a/test/boilerplate/test-index.js
+++ b/test/boilerplate/test-index.js
@@ -55,7 +55,7 @@ var amplitudeClient = function (instanceName) {
 
   this.init = function (key, arg1, settings) {
     self.settings = settings;
-    self.events = [];;
+    self.events = [];
     self.attrs = null;
     self.amount = null;
     self.quantity = null;

--- a/test/index.html
+++ b/test/index.html
@@ -67,7 +67,6 @@
 
             this.init = function(key, arg1, settings) {
                 self.settings = settings;
-                self.eventName = null;
                 self.attrs = null;
                 self.amount = null;
                 self.quantity = null;
@@ -75,6 +74,7 @@
                 self.props = null;
                 self.isOptingOut = null;
                 self.userId = null;
+                self.events = [];
             };
 
             this.logRevenue = function (amount, quantity, sku) {
@@ -88,8 +88,10 @@
             }
 
             this.logEvent = function (name, attrs) {
-                self.eventName = name;
-                self.attrs = attrs;
+                self.events.push({
+                    eventName: name,
+                    attrs: attrs
+                });
             };
 
             this.setOptOut = function (isOptingOut) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -394,16 +394,17 @@ describe('Amplitude forwarder', function () {
         mParticle.forwarder.process({
             EventDataType: MessageType.Commerce,
             EventCategory: CommerceEventType.PromotionClick,
-            PromotionAction: PromotionActionType.PromotionClick,
-            PromotionList: [
-                {
-                    Id: 'my_promo_1',
-                    Creative: 'sale_banner_1',
-                    Name: 'App-wide 50% off sale',
-                },
-            ],
+            PromotionAction: {
+                PromotionActionType: PromotionActionType.PromotionClick,
+                PromotionList: [
+                    {
+                        Id: 'my_promo_1',
+                        Creative: 'sale_banner_1',
+                        Name: 'App-wide 50% off sale',
+                    },
+                ],
+            },
         });
-        console.log(amplitude.instances.newInstance);
         amplitude.instances.newInstance.events[0].should.property(
             'eventName',
             'eCommerce - click - Item'
@@ -428,14 +429,16 @@ describe('Amplitude forwarder', function () {
         mParticle.forwarder.process({
             EventDataType: MessageType.Commerce,
             EventCategory: CommerceEventType.PromotionView,
-            PromotionAction: PromotionActionType.PromotionView,
-            PromotionList: [
-                {
-                    Id: 'my_promo_1',
-                    Creative: 'sale_banner_1',
-                    Name: 'App-wide 50% off sale',
-                },
-            ],
+            PromotionAction: {
+                PromotionActionType: PromotionActionType.PromotionView,
+                PromotionList: [
+                    {
+                        Id: 'my_promo_1',
+                        Creative: 'sale_banner_1',
+                        Name: 'App-wide 50% off sale',
+                    },
+                ],
+            },
         });
         console.log(amplitude.instances.newInstance.events);
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -246,6 +246,7 @@ describe('Amplitude forwarder', function () {
     });
 
     it('should log product impressions as events', function (done) {
+        debugger;
         mParticle.forwarder.process({
             EventDataType: MessageType.Commerce,
             EventCategory: CommerceEventType.ProductImpression,

--- a/test/tests.js
+++ b/test/tests.js
@@ -24,6 +24,11 @@ describe('Amplitude forwarder', function () {
             ProductRemoveFromWishlist: 21,
             ProductImpression: 22,
         },
+        PromotionActionType = {
+            Unknown: 0,
+            PromotionView: 1,
+            PromotionClick: 2,
+        },
         EventType = {
             Unknown: 0,
             Navigation: 1,
@@ -380,6 +385,75 @@ describe('Amplitude forwarder', function () {
         amplitude.instances.newInstance.events[1].attrs.should.have.property(
             'prodMetric1',
             'metric1'
+        );
+
+        done();
+    });
+
+    it('should log promotion clicks as events', function (done) {
+        mParticle.forwarder.process({
+            EventDataType: MessageType.Commerce,
+            EventCategory: CommerceEventType.PromotionClick,
+            PromotionAction: PromotionActionType.PromotionClick,
+            PromotionList: [
+                {
+                    Id: 'my_promo_1',
+                    Creative: 'sale_banner_1',
+                    Name: 'App-wide 50% off sale',
+                },
+            ],
+        });
+        console.log(amplitude.instances.newInstance);
+        amplitude.instances.newInstance.events[0].should.property(
+            'eventName',
+            'eCommerce - click - Item'
+        );
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
+            'Id',
+            'my_promo_1'
+        );
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
+            'Creative',
+            'sale_banner_1'
+        );
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
+            'Name',
+            'App-wide 50% off sale'
+        );
+
+        done();
+    });
+
+    it('should log promotion views as events', function (done) {
+        mParticle.forwarder.process({
+            EventDataType: MessageType.Commerce,
+            EventCategory: CommerceEventType.PromotionView,
+            PromotionAction: PromotionActionType.PromotionView,
+            PromotionList: [
+                {
+                    Id: 'my_promo_1',
+                    Creative: 'sale_banner_1',
+                    Name: 'App-wide 50% off sale',
+                },
+            ],
+        });
+        console.log(amplitude.instances.newInstance.events);
+
+        amplitude.instances.newInstance.events[0].should.property(
+            'eventName',
+            'eCommerce - view - Item'
+        );
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
+            'Id',
+            'my_promo_1'
+        );
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
+            'Creative',
+            'sale_banner_1'
+        );
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
+            'Name',
+            'App-wide 50% off sale'
         );
 
         done();

--- a/test/tests.js
+++ b/test/tests.js
@@ -9,6 +9,21 @@ describe('Amplitude forwarder', function () {
             OptOut: 6,
             Commerce: 16,
         },
+        CommerceEventType = {
+            ProductAddToCart: 10,
+            ProductRemoveFromCart: 11,
+            ProductCheckout: 12,
+            ProductCheckoutOption: 13,
+            ProductClick: 14,
+            ProductViewDetail: 15,
+            ProductPurchase: 16,
+            ProductRefund: 17,
+            PromotionView: 18,
+            PromotionClick: 19,
+            ProductAddToWishlist: 20,
+            ProductRemoveFromWishlist: 21,
+            ProductImpression: 22,
+        },
         EventType = {
             Unknown: 0,
             Navigation: 1,
@@ -193,12 +208,12 @@ describe('Amplitude forwarder', function () {
             },
         });
 
-        amplitude.instances.newInstance.should.have.property(
+        amplitude.instances.newInstance.events[0].should.have.property(
             'eventName',
             'Viewed Test Page View'
         );
-        amplitude.instances.newInstance.should.have.property('attrs');
-        amplitude.instances.newInstance.attrs.should.have.property(
+        amplitude.instances.newInstance.events[0].should.have.property('attrs');
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
             'Path',
             'Test'
         );
@@ -221,6 +236,151 @@ describe('Amplitude forwarder', function () {
         amplitude.instances.newInstance.should.have.property('amount', 400);
         amplitude.instances.newInstance.should.have.property('quantity', 1);
         amplitude.instances.newInstance.should.have.property('sku', '12345');
+
+        done();
+    });
+
+    it('should log product impressions as events', function (done) {
+        mParticle.forwarder.process({
+            EventDataType: MessageType.Commerce,
+            EventCategory: CommerceEventType.ProductImpression,
+            ProductImpressions: [
+                {
+                    ProductImpressionList: '"Suggested Products List"',
+                    ProductList: [
+                        {
+                            Attributes: {
+                                journeyType: 'testjourneytype1',
+                                eventMetric1: 'metric2',
+                            },
+                            Brand: 'brand',
+                            Category: 'category',
+                            CouponCode: 'coupon',
+                            Name: 'iphone',
+                            Position: 1,
+                            Price: 999,
+                            Quantity: 1,
+                            Sku: 'iphoneSKU',
+                            TotalAmount: 999,
+                            Variant: 'variant',
+                        },
+                        {
+                            Attributes: {
+                                attr1: 'hit-att2-type',
+                                prodMetric1: 'metric1',
+                            },
+                            Brand: 'brand',
+                            Category: 'category',
+                            CouponCode: 'coupon',
+                            Name: 'galaxy',
+                            Position: 1,
+                            Price: 799,
+                            Quantity: 1,
+                            Sku: 'galaxySKU',
+                            TotalAmount: 799,
+                            Variant: 'variant',
+                        },
+                    ],
+                },
+            ],
+        });
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
+            'Brand',
+            'brand'
+        );
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
+            'Category',
+            'category'
+        );
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
+            'Coupon Code',
+            'coupon'
+        );
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
+            'Id',
+            'iphoneSKU'
+        );
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
+            'Item Price',
+            999
+        );
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
+            'Name',
+            'iphone'
+        );
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
+            'Position',
+            1
+        );
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
+            'Product Impression List',
+            '"Suggested Products List"'
+        );
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
+            'Quantity',
+            1
+        );
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
+            'Variant',
+            'variant'
+        );
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
+            'eventMetric1',
+            'metric2'
+        );
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
+            'journeyType',
+            'testjourneytype1'
+        );
+
+        amplitude.instances.newInstance.events[1].attrs.should.have.property(
+            'Brand',
+            'brand'
+        );
+        amplitude.instances.newInstance.events[1].attrs.should.have.property(
+            'Category',
+            'category'
+        );
+        amplitude.instances.newInstance.events[1].attrs.should.have.property(
+            'Coupon Code',
+            'coupon'
+        );
+        amplitude.instances.newInstance.events[1].attrs.should.have.property(
+            'Id',
+            'galaxySKU'
+        );
+        amplitude.instances.newInstance.events[1].attrs.should.have.property(
+            'Item Price',
+            799
+        );
+        amplitude.instances.newInstance.events[1].attrs.should.have.property(
+            'Name',
+            'galaxy'
+        );
+        amplitude.instances.newInstance.events[1].attrs.should.have.property(
+            'Position',
+            1
+        );
+        amplitude.instances.newInstance.events[1].attrs.should.have.property(
+            'Product Impression List',
+            '"Suggested Products List"'
+        );
+        amplitude.instances.newInstance.events[1].attrs.should.have.property(
+            'Quantity',
+            1
+        );
+        amplitude.instances.newInstance.events[1].attrs.should.have.property(
+            'Variant',
+            'variant'
+        );
+        amplitude.instances.newInstance.events[1].attrs.should.have.property(
+            'attr1',
+            'hit-att2-type'
+        );
+        amplitude.instances.newInstance.events[1].attrs.should.have.property(
+            'prodMetric1',
+            'metric1'
+        );
 
         done();
     });
@@ -713,31 +873,31 @@ describe('Amplitude forwarder', function () {
         );
 
         // Product level attributes
-        amplitude.instances.newInstance.attrs.should.have.property(
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
             'Id',
             '12345'
         );
-        amplitude.instances.newInstance.attrs.should.have.property(
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
             'Item Price',
             400
         );
-        amplitude.instances.newInstance.attrs.should.have.property(
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
             'Quantity',
             1
         );
-        amplitude.instances.newInstance.attrs.should.have.property(
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
             'Transaction Id',
             123
         );
-        amplitude.instances.newInstance.attrs.should.have.property(
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
             'CustomEventAttribute',
             'SomeEventAttributeValue'
         );
-        amplitude.instances.newInstance.attrs.should.have.property(
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
             'CustomProductAttribute',
             'Cool'
         );
-        amplitude.instances.newInstance.attrs.should.not.property(
+        amplitude.instances.newInstance.events[0].attrs.should.not.property(
             'Total Product Amount'
         );
 
@@ -803,31 +963,31 @@ describe('Amplitude forwarder', function () {
         );
 
         // Product level attributes
-        amplitude.instances.newInstance.attrs.should.have.property(
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
             'Id',
             '12345'
         );
-        amplitude.instances.newInstance.attrs.should.have.property(
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
             'Item Price',
             400
         );
-        amplitude.instances.newInstance.attrs.should.have.property(
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
             'Quantity',
             1
         );
-        amplitude.instances.newInstance.attrs.should.have.property(
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
             'Transaction Id',
             123
         );
-        amplitude.instances.newInstance.attrs.should.have.property(
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
             'CustomEventAttribute',
             'SomeEventAttributeValue'
         );
-        amplitude.instances.newInstance.attrs.should.have.property(
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
             'CustomProductAttribute',
             'Cool'
         );
-        amplitude.instances.newInstance.attrs.should.not.property(
+        amplitude.instances.newInstance.events[0].attrs.should.not.property(
             'Total Product Amount'
         );
 
@@ -863,31 +1023,31 @@ describe('Amplitude forwarder', function () {
         amplitude.instances.newInstance.should.not.have.property('revenueObj');
 
         // Product level attributes
-        amplitude.instances.newInstance.attrs.should.have.property(
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
             'Id',
             '12345'
         );
-        amplitude.instances.newInstance.attrs.should.have.property(
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
             'Item Price',
             400
         );
-        amplitude.instances.newInstance.attrs.should.have.property(
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
             'Quantity',
             1
         );
-        amplitude.instances.newInstance.attrs.should.have.property(
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
             'Transaction Id',
             123
         );
-        amplitude.instances.newInstance.attrs.should.have.property(
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
             'CustomEventAttribute',
             'SomeEventAttributeValue'
         );
-        amplitude.instances.newInstance.attrs.should.have.property(
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
             'CustomProductAttribute',
             'Cool'
         );
-        amplitude.instances.newInstance.attrs.should.not.property(
+        amplitude.instances.newInstance.events[0].attrs.should.not.property(
             'Total Product Amount'
         );
 
@@ -923,31 +1083,31 @@ describe('Amplitude forwarder', function () {
         amplitude.instances.newInstance.should.not.have.property('revenueObj');
 
         // Product level attributes
-        amplitude.instances.newInstance.attrs.should.have.property(
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
             'Id',
             '12345'
         );
-        amplitude.instances.newInstance.attrs.should.have.property(
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
             'Item Price',
             400
         );
-        amplitude.instances.newInstance.attrs.should.have.property(
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
             'Quantity',
             1
         );
-        amplitude.instances.newInstance.attrs.should.have.property(
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
             'Transaction Id',
             123
         );
-        amplitude.instances.newInstance.attrs.should.have.property(
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
             'CustomEventAttribute',
             'SomeEventAttributeValue'
         );
-        amplitude.instances.newInstance.attrs.should.have.property(
+        amplitude.instances.newInstance.events[0].attrs.should.have.property(
             'CustomProductAttribute',
             'Cool'
         );
-        amplitude.instances.newInstance.attrs.should.not.property(
+        amplitude.instances.newInstance.events[0].attrs.should.not.property(
             'Total Product Amount'
         );
 
@@ -1003,20 +1163,22 @@ describe('Amplitude forwarder', function () {
                 },
             });
 
-            amplitude.instances.newInstance.should.have.property(
+            amplitude.instances.newInstance.events[0].should.have.property(
                 'eventName',
                 'Viewed Test Page View'
             );
-            amplitude.instances.newInstance.should.have.property('attrs');
-            amplitude.instances.newInstance.attrs.should.have.property(
+            amplitude.instances.newInstance.events[0].should.have.property(
+                'attrs'
+            );
+            amplitude.instances.newInstance.events[0].attrs.should.have.property(
                 'Path',
                 'Test'
             );
-            amplitude.instances.newInstance.attrs.should.have.property(
+            amplitude.instances.newInstance.events[0].attrs.should.have.property(
                 'Array',
                 ['abc', 'def', 'ghi']
             );
-            amplitude.instances.newInstance.attrs.Obj.should.have.property(
+            amplitude.instances.newInstance.events[0].attrs.Obj.should.have.property(
                 'foo',
                 'bar'
             );
@@ -1064,15 +1226,15 @@ describe('Amplitude forwarder', function () {
             );
 
             // Product level attributes
-            amplitude.instances.newInstance.attrs.should.have.property(
+            amplitude.instances.newInstance.events[0].attrs.should.have.property(
                 'CustomEventAttribute',
                 'SomeEventAttributeValue'
             );
-            amplitude.instances.newInstance.attrs.should.have.property(
+            amplitude.instances.newInstance.events[0].attrs.should.have.property(
                 'Array',
                 ['abc', 'def', 'ghi']
             );
-            amplitude.instances.newInstance.attrs.Obj.should.have.property(
+            amplitude.instances.newInstance.events[0].attrs.Obj.should.have.property(
                 'foo',
                 'bar'
             );
@@ -1090,15 +1252,15 @@ describe('Amplitude forwarder', function () {
                 },
             });
 
-            amplitude.instances.newInstance.attrs.should.have.property(
+            amplitude.instances.newInstance.events[0].attrs.should.have.property(
                 'CustomEventAttribute',
                 'SomeEventAttributeValue'
             );
-            amplitude.instances.newInstance.attrs.should.have.property(
+            amplitude.instances.newInstance.events[0].attrs.should.have.property(
                 'Array',
                 ['abc', 'def', 'ghi']
             );
-            amplitude.instances.newInstance.attrs.Obj.should.have.property(
+            amplitude.instances.newInstance.events[0].attrs.Obj.should.have.property(
                 'foo',
                 'bar'
             );


### PR DESCRIPTION
The server maps product impressions. Web Kit currently does not.  This PR allows product impressions to be sent as regular events, since the Amplitude SDK does not support a direct mapping.