### PR TITLE
Remove JSON.stringify from products

### DIFF
--- a/src/Amplitude.js
+++ b/src/Amplitude.js
@@ -463,7 +463,7 @@ var constructor = function () {
         );
         updatedAttributes[MP_AMP_SPLIT] = false;
 
-        updatedAttributes[PRODUCTS] = JSON.stringify(products);
+        updatedAttributes[PRODUCTS] = products;
         var revenueEventLabel = isRefund ? REFUND : PURCHASE;
         getInstance().logEvent(
             'eCommerce - ' + revenueEventLabel,
@@ -516,9 +516,8 @@ var constructor = function () {
         );
         updatedAttributes[MP_AMP_SPLIT] = false;
         try {
-            updatedAttributes[PRODUCTS] = JSON.stringify(
-                summaryEvent.ProductAction.ProductList
-            );
+            updatedAttributes[PRODUCTS] =
+                summaryEvent.ProductAction.ProductList;
         } catch (e) {
             console.error('error adding Product List to summary event');
         }

--- a/test/tests.js
+++ b/test/tests.js
@@ -1106,7 +1106,7 @@ describe('Amplitude forwarder', function () {
                         'Tax Amount': 30,
                         'Transaction Id': 'foo-transaction-id',
                         mparticle_amplitude_should_split: false,
-                        products: JSON.stringify([product1, product2]),
+                        products: [product1, product2],
                         sale: true,
                     }
                 );
@@ -1136,7 +1136,7 @@ describe('Amplitude forwarder', function () {
                         'Tax Amount': 30,
                         'Transaction Id': 'foo-transaction-id',
                         mparticle_amplitude_should_split: false,
-                        products: JSON.stringify([product1, product2]),
+                        products: [product1, product2],
                         sale: true,
                     }
                 );
@@ -1168,7 +1168,7 @@ describe('Amplitude forwarder', function () {
                 );
                 amplitude.instances.newInstance.events[0].attrs.should.have.property(
                     'products',
-                    JSON.stringify([product1, product2])
+                    [product1, product2]
                 );
 
                 done();
@@ -1198,7 +1198,7 @@ describe('Amplitude forwarder', function () {
                 );
                 amplitude.instances.newInstance.events[0].attrs.should.have.property(
                     'products',
-                    JSON.stringify([product1, product2])
+                    [product1, product2]
                 );
 
                 done();
@@ -1245,7 +1245,7 @@ describe('Amplitude forwarder', function () {
                         'Tax Amount': 30,
                         'Transaction Id': 'foo-transaction-id',
                         mparticle_amplitude_should_split: false,
-                        products: JSON.stringify([product1, product2]),
+                        products: [product1, product2],
                         sale: true,
                     }
                 );
@@ -1336,7 +1336,7 @@ describe('Amplitude forwarder', function () {
                         'Tax Amount': 30,
                         'Transaction Id': 'foo-transaction-id',
                         mparticle_amplitude_should_split: false,
-                        products: JSON.stringify([product1, product2]),
+                        products: [product1, product2],
                         sale: true,
                     }
                 );
@@ -1435,7 +1435,7 @@ describe('Amplitude forwarder', function () {
                 );
                 amplitude.instances.newInstance.events[0].attrs.should.have.property(
                     'products',
-                    JSON.stringify([product1, product2])
+                    [product1, product2]
                 );
 
                 amplitude.instances.newInstance.events[1].should.have.property(
@@ -1520,7 +1520,7 @@ describe('Amplitude forwarder', function () {
                 );
                 amplitude.instances.newInstance.events[0].attrs.should.have.property(
                     'products',
-                    JSON.stringify([product1, product2])
+                    [product1, product2]
                 );
 
                 amplitude.instances.newInstance.events[1].should.have.property(


### PR DESCRIPTION
## Summary
Amplitude provided feedback that the products array should not be sent as a string.

## Testing Plan
Updated unit tests

## Reference Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4471
