### PR TITLE
fix: Add return after previous code path

### DIFF
--- a/src/Amplitude.js
+++ b/src/Amplitude.js
@@ -389,6 +389,8 @@ var constructor = function () {
                         );
                     }
                 });
+
+                return true;
             }
         }
 


### PR DESCRIPTION
## Summary
A `return true` was left out when bringing back the [previous code path](https://github.com/mparticle-integrations/mparticle-javascript-integration-amplitude/blob/master/src/Amplitude.js#L350-L374).

I caught this when manually testing and even though it successfully passed an event to Amplitude, it still reached the code at the end of the function block and console.logged the error `Commerce event does not conform to our expectations and was not forwarded to Amplitude. Please double-check your code.`, even though the event was sent.

## Testing Plan
Manual tests 