### PR TITLE
feat: Add support for Amplitude JS v8.21.8

### DIFF
--- a/src/Amplitude.js
+++ b/src/Amplitude.js
@@ -60,28 +60,32 @@ var includeIndividualProductEvents,
 // prettier-ignore
 var renderSnippet = function() {
         (function(e,t){var n=e.amplitude||{_q:[],_iq:{}};var r=t.createElement("script")
-        ;r.type="text/javascript"
-        ;r.integrity="sha384-girahbTbYZ9tT03PWWj0mEVgyxtZoyDF9KVZdL+R53PP5wCY0PiVUKq0jeRlMx9M"
-        ;r.crossOrigin="anonymous";r.async=true
-        ;r.src="https://cdn.amplitude.com/libs/amplitude-7.2.1-min.gz.js"
-        ;r.onload=function(){if(!e.amplitude.runQueuedFunctions){
-        console.log("[Amplitude] Error: could not load SDK")}}
-        ;var i=t.getElementsByTagName("script")[0];i.parentNode.insertBefore(r,i)
-        ;function s(e,t){e.prototype[t]=function(){
+        r.type="text/javascript";
+        r.integrity="sha384-QahB0HKETlcqjneomU3Ohs+UgJTinhUNFIKJitEl2Vo7DjvphO2jei64ZP5J2GA5"
+        r.crossOrigin="anonymous";r.async=true;
+        r.src="https://cdn.amplitude.com/libs/amplitude-8.21.8-min.gz.js";
+        r.onload=function(){if(!e.amplitude.runQueuedFunctions){console.log(
+        "[Amplitude] Error: could not load SDK")}};var s=t.getElementsByTagName("script"
+        )[0];s.parentNode.insertBefore(r,s);function i(e,t){e.prototype[t]=function(){
         this._q.push([t].concat(Array.prototype.slice.call(arguments,0)));return this}}
-        var o=function(){this._q=[];return this}
-        ;var a=["add","append","clearAll","prepend","set","setOnce","unset"]
-        ;for(var c=0;c<a.length;c++){s(o,a[c])}n.Identify=o;var u=function(){this._q=[]
-        ;return this}
-        ;var l=["setProductId","setQuantity","setPrice","setRevenueType","setEventProperties"]
-        ;for(var p=0;p<l.length;p++){s(u,l[p])}n.Revenue=u
-        ;var d=["init","logEvent","logRevenue","setUserId","setUserProperties","setOptOut","setVersionName","setDomain","setDeviceId","enableTracking","setGlobalUserProperties","identify","clearUserProperties","setGroup","logRevenueV2","regenerateDeviceId","groupIdentify","onInit","logEventWithTimestamp","logEventWithGroups","setSessionId","resetSessionId"]
-        ;function v(e){function t(t){e[t]=function(){
-        e._q.push([t].concat(Array.prototype.slice.call(arguments,0)))}}
-        for(var n=0;n<d.length;n++){t(d[n])}}v(n);n.getInstance=function(e){
-        e=(!e||e.length===0?"$default_instance":e).toLowerCase()
-        ;if(!n._iq.hasOwnProperty(e)){n._iq[e]={_q:[]};v(n._iq[e])}return n._iq[e]}
-        ;e.amplitude=n})(window,document);
+        var o=function(){this._q=[];return this};var a=["add","append","clearAll",
+        "prepend","set","setOnce","unset","preInsert","postInsert","remove"];for(
+        var c=0;c<a.length;c++){i(o,a[c])}n.Identify=o;var l=function(){this._q=[];
+        return this};var p=["setProductId","setQuantity","setPrice","setRevenueType",
+        "setEventProperties"];for(var u=0;u<p.length;u++){i(l,p[u])}n.Revenue=l;var d=[
+        "init","logEvent","logRevenue","setUserId","setUserProperties","setOptOut",
+        "setVersionName","setDomain","setDeviceId","enableTracking",
+        "setGlobalUserProperties","identify","clearUserProperties","setGroup",
+        "logRevenueV2","regenerateDeviceId","groupIdentify","onInit","onNewSessionStart"
+        ,"logEventWithTimestamp","logEventWithGroups","setSessionId","resetSessionId",
+        "getDeviceId","getUserId","setMinTimeBetweenSessionsMillis",
+        "setEventUploadThreshold","setUseDynamicConfig","setServerZone","setServerUrl",
+        "sendEvents","setLibrary","setTransport"];function v(t){function e(e){t[e
+        ]=function(){t._q.push([e].concat(Array.prototype.slice.call(arguments,0)))}}
+        for(var n=0;n<d.length;n++){e(d[n])}}v(n);n.getInstance=function(e){e=(
+        !e||e.length===0?"$default_instance":e).toLowerCase();if(
+        !Object.prototype.hasOwnProperty.call(n._iq,e)){n._iq[e]={_q:[]};v(n._iq[e])}
+        return n._iq[e]};e.amplitude=n})(window,document);
         /* eslint-enable */
 };
 


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Migrate Amplitude JS from [v7.2.1 to v8.21.8](https://github.com/amplitude/amplitude-javascript/compare/v7.2.1...v8.21.8)
 - Mostly consists of bug fixes, but now provides support for `sendBeacon` via an init option
 - BREAKING CHANGE: Removes support for React Native

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Set up a sample app using the updated kit and verify that existing functionality continues to work

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5826
